### PR TITLE
Added optech taproot/schnorr library to PoC projects.

### DIFF
--- a/PoC-Projects.md
+++ b/PoC-Projects.md
@@ -1,6 +1,6 @@
 # Proof of Concept Projects
 
-These are some ideas for proof of concept projects to explore schnorr and/or taproot in more depth.
+These are some ideas for proof of concept projects to explore Schnorr and/or taproot in more depth.
 
  * LN payment points and scalars
  * LN 2-of-2 Schnorr MuSig construction for channel open/close
@@ -9,3 +9,4 @@ These are some ideas for proof of concept projects to explore schnorr and/or tap
  * Taproot/Schnorr support for python-bitcoinlib (etc?)
  * ...
 
+Note: Optech has developed a [Schnorr & Taproot library](https://github.com/bitcoinops/taproot-workshop), which can be used to prototype many of the proof-of-concept projects suggested above. The library features a Schnorr and MuSig implementation as well as methods to construct Taproot outputs from various types of Tapscripts. The documentation is written in the form of interactive Jupyter notebooks, which provide thorough examples on how to use the library.


### PR DESCRIPTION
Thanks for setting this repository up. I built a Schnorr/MuSig/Taproot library for Optech this summer at the Chaincode residency. The workshop repository which is linked contains a pretty complete Taproot library, with which most of the currently listed PoC projects could be built rather easily. For the purpose of evaluating the Schnorr/Taproot proposals, I suggest participants consider this PoC toolkit first, before investing time to reinvent the wheel?