### PR TITLE
Add Bitcoin Optech schnorr/taproot workshop to PoCs

### DIFF
--- a/PoC-Projects.md
+++ b/PoC-Projects.md
@@ -7,5 +7,6 @@ These are some ideas for proof of concept projects to explore schnorr and/or tap
  * Off-chain 2-of-3 key rotation
  * Liquid-style 11-of-15 multisig
  * Taproot/Schnorr support for python-bitcoinlib (etc?)
+ * Continue updating the [Bitcoin Optech schnorr/taproot workshop](https://github.com/bitcoinops/taproot-workshop), including adding new case studies.
  * ...
 


### PR DESCRIPTION
Not sure if this counts as a PoC. I think that the optech schnorr/taproot workshop notebooks are a great demonstration of the technology, and people could add new case studies to show different applications of schnorr/taproot.